### PR TITLE
Mark as multiprocess compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ repository from:
 
 After modifying the source code, you need to commit your changes to
 your local Git repository. You can then run `build.sh` from the
-root of the repository.
+root of the repository. `build.sh` will create `samltracer.xpi` from
+the latest commit in your repository.
 
-`build.sh` will create `samltracer.xpi` from the latest commit in
-your repository. This `xpi`-file can then be loaded into Firefox
-by running `firefox samltracer.xpi` (or opening the file in Firefox).
+You need to set `xpinstall.signatures.required` to false in Firefox
+`about:config` to be able to load this `xpi`-file. You can then run
+`firefox samltracer.xpi` (or open the file in Firefox). Don't forget
+to re-enable `xpinstall.signatures.required` when you're done.
 
 
 License

--- a/install.rdf
+++ b/install.rdf
@@ -10,6 +10,7 @@
     <em:version>0.3.3</em:version>
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
+    <em:multiprocessCompatible>true</em:multiprocessCompatible>
 
     <!-- Mozilla Firefox -->
     <em:targetApplication>


### PR DESCRIPTION
As @andreicristianpetcu described in #18 this is necessary to avoid loading compatibility shims. I've been testing with this setting on and SAML Tracer works fine for me.