### PR TITLE
Feature/scrollable list

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -152,9 +152,9 @@ SAMLTrace.Request.prototype = {
   },
   'loadResponse' : function() {
     let response = this.getResponse();
-    this.responseStatus = response.statusCode;
-    this.responseStatusText = response.statusLine;
-    this.responseHeaders = response.responseHeaders;
+    this.responseStatus = response ? response.statusCode : "";
+    this.responseStatusText = response ? response.statusLine : "";
+    this.responseHeaders = response ? response.responseHeaders: [];
   },
   'loadGET' : function() {
     if (this.method !== 'GET') {

--- a/src/TraceWindow.html
+++ b/src/TraceWindow.html
@@ -39,6 +39,7 @@
         <script type="text/javascript" src="hash.js"></script>
         <script type="text/javascript" src="SAMLTrace.js"></script>
         <script type="text/javascript" src="ui.js"></script>
+        <script type="text/javascript" src="scrollableList.js"></script>
         <script type="text/javascript" src="../lib/pako_inflate.js"></script>
         <script type="text/javascript" src="../lib/highlight.pack.js"></script>
     </body>

--- a/src/scrollableList.js
+++ b/src/scrollableList.js
@@ -1,0 +1,98 @@
+/**
+ * Handles keyboard events to select an appropriate request row
+ **/
+
+if ("undefined" === typeof(ScrollableList)) {
+  var ScrollableList = new function() {
+
+    const isElementToBeSkipped = elem => {
+      return elem && elem.classList.contains("isRessource") && !elem.classList.contains("displayAnyway");
+    };
+
+    const getSibling = (cur, siblingFunc) => {
+      while (cur !== null && isElementToBeSkipped(cur)) {
+        cur = siblingFunc(cur);
+      }
+      return cur;
+    };
+
+    const getVisibleSiblingOnOtherPage = (cur, siblingFunc, e) => {
+      const getNthVisibleSibling = (cur, n) => {
+        let index = 0;
+        let lastRelevant = cur;
+        let sibling = null;
+        do {
+          sibling = siblingFunc(cur);
+          if (sibling) {
+            if (!isElementToBeSkipped(sibling)) {
+              index++;
+              lastRelevant = sibling;
+            }
+            cur = sibling;
+          }
+        } while (sibling && index < n);
+
+        return lastRelevant;
+      };
+
+      let fullRowsPerScreen = Math.floor(this.list.clientHeight / cur.offsetHeight);
+      let fullRowsExceptOwnRow = fullRowsPerScreen - 1;
+      let firstVisibleSibling = getNthVisibleSibling(cur, fullRowsExceptOwnRow);
+      bringItemIntoVisibleArea(firstVisibleSibling, e);
+      return firstVisibleSibling;
+    };
+
+    const bringItemIntoVisibleArea = (newElem, e) => {
+      if (!newElem) {
+        return;
+      }
+
+      const isTopVisible = elem => {
+        return elem.offsetTop >= this.list.offsetTop + this.list.scrollTop;
+      };
+
+      const isBottomVisible = elem => {
+        return this.list.offsetTop + this.list.clientHeight + this.list.scrollTop >= elem.offsetTop + elem.offsetHeight;
+      };
+
+      // prevent the default scroll event
+      e.preventDefault();
+
+      // and take care of the new items' visibility on our own
+      if (!isTopVisible(newElem)) {
+        this.list.scrollTop = newElem.offsetTop - this.list.offsetTop - newElem.offsetHeight + this.list.scrollTop % newElem.offsetHeight;
+      } else if (!isBottomVisible(newElem)) {
+        this.list.scrollTop = newElem.offsetTop - this.list.clientHeight;
+      }
+    };
+
+    this.selectRowOnKeybeardEvent = (e, list, onNewElementSelected) => {
+      this.list = list;
+      let newElement = null;
+      let selectedElement = this.list.querySelector(".selected");
+      if (!selectedElement) {
+        selectedElement = this.list.firstChild;
+      }
+
+      if (e.key === "ArrowUp") {
+        newElement = getSibling(selectedElement.previousSibling, elem => elem.previousSibling);
+        bringItemIntoVisibleArea(newElement, e);
+      } else if (e.key === "ArrowDown") {
+        newElement = getSibling(selectedElement.nextSibling, elem => elem.nextSibling);
+        bringItemIntoVisibleArea(newElement, e);
+      } else if (e.key === "PageUp") {
+        newElement = getVisibleSiblingOnOtherPage(selectedElement, elem => elem.previousSibling, e);
+      } else if (e.key === "PageDown") {
+        newElement = getVisibleSiblingOnOtherPage(selectedElement, elem => elem.nextSibling, e);
+      } else if (e.key === "Home") {
+        newElement = getSibling(this.list.firstChild, elem => elem.nextSibling);
+      } else if (e.key === "End") {
+        newElement = getSibling(this.list.lastChild, elem => elem.previousSibling);
+      }
+
+      if (newElement) {
+        onNewElementSelected(newElement);
+      }
+    };
+  };
+};

--- a/src/ui.js
+++ b/src/ui.js
@@ -100,10 +100,21 @@ ui = {
       }
     };
 
+    const selectRowOnKeybeardEvent = e => {
+      // select another request, when ArrowUp, ArrowDown, PageUp, PageDown, Home or End are pressed
+      let requestList = document.getElementById("request-list");
+      ScrollableList.selectRowOnKeybeardEvent(e, requestList, newElement => {
+        window.tracer.selectItemInList(newElement, requestList);
+        window.tracer.showRequest(newElement.requestItem);
+        ui.highlightContent();
+      });
+    };
+
     let iframes = document.querySelectorAll("iframe");
     iframes.forEach(iframe => iframe.contentWindow.document.addEventListener("keydown", closeDialogs));
     document.addEventListener("keydown", closeDialogs);
     document.addEventListener("keydown", selectRequestInfoContent);
+    document.addEventListener("keydown", selectRowOnKeybeardEvent);
   },
 
   initContentSplitter: function() {
@@ -125,9 +136,9 @@ ui = {
     });
   },
   
-  enableSyntaxHighlighting: function() {
+  highlightContent: () => {
     const getSyntaxHighlightingClass = tab => {
-      let tabName = tab.href.split('#')[1];
+      let tabName = tab ? tab.href.split('#')[1] : "n/a";
       if (tabName === "HTTP" || tabName === "Parameters") {
         return "HTTP";
       } else {
@@ -140,20 +151,20 @@ ui = {
       syntaxHighlightingClasses.forEach(c => block.classList.remove(c));
     };
 
-    const highlightContent = () => {
-      let content = document.querySelector("#request-info-content");
-      removeSyntaxHighlightingClasses(content);
+    let content = document.querySelector("#request-info-content");
+    removeSyntaxHighlightingClasses(content);
 
-      let selectedTab = document.querySelector(".tab.selected");
-      let syntaxHighlightingClass = getSyntaxHighlightingClass(selectedTab);
-      content.classList.add(syntaxHighlightingClass);
-      hljs.highlightBlock(content);
-    }
-
+    let selectedTab = document.querySelector(".tab.selected");
+    let syntaxHighlightingClass = getSyntaxHighlightingClass(selectedTab);
+    content.classList.add(syntaxHighlightingClass);
+    hljs.highlightBlock(content);
+  },
+  
+  enableSyntaxHighlighting: function() {
     let tabBox = document.querySelector("#request-info-tabbox");
-    tabBox.addEventListener("click", highlightContent);
+    tabBox.addEventListener("click", ui.highlightContent);
 
     let requestList = document.querySelector("#request-list");
-    requestList.addEventListener("click", highlightContent);
+    requestList.addEventListener("click", ui.highlightContent);
   }
 }


### PR DESCRIPTION
Elements in the requests list can now be selected upon various keyboard events.

This is a functionality that got lost during the web extension conversion.
It's now (again) possible to select requests when <kbd>ArrowUp</kbd>, <kbd>ArrowDown</kbd>, <kbd>PageUp</kbd>, <kbd>PageDown</kbd>, <kbd>Home</kbd> or <kbd>End</kbd> are pressed.

![peek 2018-02-04 19-29](https://user-images.githubusercontent.com/17160647/35780822-e3edc818-09e1-11e8-927b-0ce87ccc46d8.gif)
