### PR TITLE
Deactivate autoscroll on scroll up and reactivate when scrolled down.

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -4,6 +4,7 @@ window.addEventListener("load", function(e) {
   ui.resizeDialogs();
   ui.bindButtons();
   ui.bindKeys();
+  ui.bindScrollRequestList();
   ui.initContentSplitter();
   ui.enableSyntaxHighlighting();
 
@@ -41,8 +42,13 @@ ui = {
 
   toggleButtonState: function(button) {
     let isActive = button.classList.contains("active");
-    isActive ? button.classList.remove("active") : button.classList.add("active");
-    return !isActive;
+    let newState = !isActive;
+    ui.setButtonState(button, newState)
+    return newState;
+  },
+
+  setButtonState: function(button, newState) {
+    newState ? button.classList.add("active") : button.classList.remove("active");
   },
 
   bindButtons: function() {
@@ -129,6 +135,19 @@ ui = {
     document.addEventListener("keydown", selectRequestInfoContent);
     document.addEventListener("keydown", selectRowOnKeybeardEvent);
     document.addEventListener("keydown", togglePauseTracing);
+  },
+
+  bindScrollRequestList: function() {
+    let requestList = document.getElementById("request-list");
+    let autoScrollButton = document.getElementById("button-autoscroll");
+
+    requestList.addEventListener("scroll", e => {
+      let wasScrolledUp = requestList.scrollTop < requestList.scrollTopMax;
+      let activateAutoscroll = !wasScrolledUp;
+
+      ui.setButtonState(autoScrollButton, activateAutoscroll);
+      window.tracer.setAutoscroll(activateAutoscroll);
+    });
   },
 
   initContentSplitter: function() {

--- a/src/ui.js
+++ b/src/ui.js
@@ -62,6 +62,10 @@ ui = {
     document.getElementById("button-autoscroll").addEventListener("click", e => {
       let newState = ui.toggleButtonState(e.target);
       window.tracer.setAutoscroll(newState);
+      if (newState === true) {
+        let requestList = document.getElementById("request-list");
+        requestList.scrollTop = requestList.scrollTopMax;
+      }
     }, true);
     document.getElementById("button-filter").addEventListener("click", e => {
       let newState = ui.toggleButtonState(e.target);


### PR DESCRIPTION
Does this sound familiar to you? You're investigating a certain request. And then - a late response drops in and the request list scrolls down to the bottom.

This pull request handles exactly this. When you scroll up, the autoscroll functionality gets disabled and re-enabled when you again scroll down to the bottom.
