### PR TITLE
changes for other browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+samltracer.zip

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2,6 +2,8 @@
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Specifying_background_scripts
 // The onOpenWindow event handler was slightly modified to be compatible with standard Firefox.
 
+var browser = browser || chrome
+
 browser.browserAction.onClicked.addListener((tab) => showTracerWindow());
 
 var tracerWindow = null;

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,7 +3,6 @@
 // The onOpenWindow event handler was slightly modified to be compatible with standard Firefox.
 
 var browser = browser || chrome
-
 browser.browserAction.onClicked.addListener((tab) => showTracerWindow());
 
 var tracerWindow = null;
@@ -16,14 +15,18 @@ function showTracerWindow() {
   }
 
   // If it wasn't yet opened or it was already closed -- create a new instance.
-  var url = browser.extension.getURL("/src/TraceWindow.html");
-  var creating = browser.windows.create({
+  let url = browser.extension.getURL("/src/TraceWindow.html");
+  let creating = browser.windows.create({
     url: url,
-    type: "panel",
+    type: "popup",
     height: 600,
     width: 800
-  });
-  creating.then(onCreated, onError);
+  }, onCreated);
+
+  if (creating) {
+    // Firefox uses a promise for window creation
+    creating.then(onCreated, onError); 
+  }
 }
 
 function onCreated(windowInfo) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,11 @@
     "description": "A debugger for viewing SAML messages",
     "manifest_version": 2,
     "version": "1.4",
-    "applications": {
-        "gecko": {
-          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
-        }
-    },
+//    "applications": {
+//        "gecko": {
+//          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
+//        }
+//    },
     "homepage_url": "https://github.com/UNINETT/SAML-tracer",
     "icons": {
         "48": "src/resources/images/saml-as-square.png"

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,22 @@
 {
-    "name": "SAML-tracer",
-    "description": "A debugger for viewing SAML messages",
-    "manifest_version": 2,
-    "version": "1.4",
-//    "applications": {
-//        "gecko": {
-//          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
-//        }
-//    },
-    "homepage_url": "https://github.com/UNINETT/SAML-tracer",
-    "icons": {
-        "48": "src/resources/images/saml-as-square.png"
-    },
-    "permissions": [
-        "webRequest",
-        "webRequestBlocking",
-        "<all_urls>"
-    ],
-    "background": {
-        "scripts": ["bootstrap.js"]
-    },
-    "browser_action": {
-        "default_icon": "src/resources/images/saml-as-square.png"
-    }
+  "name": "SAML-tracer",
+  "description": "A debugger for viewing SAML messages",
+  "author": "Olav Morken, Jaime Perez",
+  "manifest_version": 2,
+  "version": "1.4",
+  "homepage_url": "https://github.com/UNINETT/SAML-tracer",
+  "icons": {
+    "48": "src/resources/images/saml-as-square.png"
+  },
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
+  "background": {
+    "scripts": ["bootstrap.js"]
+  },
+  "browser_action": {
+    "default_icon": "src/resources/images/saml-as-square.png"
+  }
 }

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -1,4 +1,6 @@
 // export SAMLTrace namespace to make ao. Request definitions available
+var browser = browser || chrome
+
 var EXPORTED_SYMBOLS = ["SAMLTrace"];
 
 if ("undefined" == typeof(SAMLTrace)) {

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -1,6 +1,4 @@
 // export SAMLTrace namespace to make ao. Request definitions available
-var browser = browser || chrome
-
 var EXPORTED_SYMBOLS = ["SAMLTrace"];
 
 if ("undefined" == typeof(SAMLTrace)) {
@@ -704,6 +702,7 @@ SAMLTrace.TraceWindow.prototype = {
 };
 
 SAMLTrace.TraceWindow.init = function() {
+  var browser = browser || chrome;
   let traceWindow = new SAMLTrace.TraceWindow();
   
   browser.webRequest.onBeforeRequest.addListener(

--- a/src/splitter.js
+++ b/src/splitter.js
@@ -1,42 +1,52 @@
 Splitter = {
-    setup: function(controlTop, controlBottom, dragger) {
-        Splitter.controlTop = controlTop;
-        Splitter.controlBottom = controlBottom;
-        dragger.onmousedown = Splitter.mousedown;
-    },
-    mousedown: function(e) {
-        Splitter.lastPosition = e.clientY;
-        document.onmousemove = Splitter.move;
-        document.onmouseup = Splitter.stop;
-    },
-    move: function(e) {
-        let vMovement = e.clientY - Splitter.lastPosition;
-        let controlTopNewHeight = Splitter.controlTop.clientHeight + vMovement;
-        let controlBottomNewHeight = Splitter.controlBottom.clientHeight - vMovement;
+  setup: function(controlTop, controlBottom, dragger) {
+    const justifyHeights = (controlTop, controlBottom) => {
+      let maxHeight = controlTop.clientHeight + controlBottom.clientHeight;
+      controlTop.style.height = maxHeight / 2 + "px";
+      controlBottom.style.height = maxHeight / 2 + "px";
+    };
 
-        let position = e.clientY;
-        if (controlTopNewHeight < 0) {
-            controlBottomNewHeight += controlTopNewHeight;
-            controlTopNewHeight = 0;
-            topManipulated = true;
-        }
-        if (controlBottomNewHeight < 0) {
-            controlTopNewHeight += controlBottomNewHeight;
-            controlBottomNewHeight = 0;
-            bottomManipulated = true;
-        }
+    justifyHeights(controlTop, controlBottom);
+    Splitter.controlTop = controlTop;
+    Splitter.controlBottom = controlBottom;
+    dragger.onmousedown = Splitter.mousedown;
+  },
 
-        const getPaddingHeight = element => {
-            let style = window.getComputedStyle(element);
-            return parseInt(style.paddingTop) + parseInt(style.paddingBottom);
-        };
+  mousedown: function(e) {
+    Splitter.lastPosition = e.clientY;
+    document.onmousemove = Splitter.move;
+    document.onmouseup = Splitter.stop;
+  },
 
-        Splitter.controlTop.style.height = (controlTopNewHeight - getPaddingHeight(Splitter.controlTop)) + "px";
-        Splitter.controlBottom.style.height = (controlBottomNewHeight - getPaddingHeight(Splitter.controlBottom)) + "px";
-        Splitter.lastPosition = e.clientY;
-    },
-    stop: function() {
-        document.onmousemove = null;
-        document.onmouseup = null;
+  move: function(e) {
+    let vMovement = e.clientY - Splitter.lastPosition;
+    let controlTopNewHeight = Splitter.controlTop.clientHeight + vMovement;
+    let controlBottomNewHeight = Splitter.controlBottom.clientHeight - vMovement;
+
+    let position = e.clientY;
+    if (controlTopNewHeight < 0) {
+      controlBottomNewHeight += controlTopNewHeight;
+      controlTopNewHeight = 0;
+      topManipulated = true;
     }
+    if (controlBottomNewHeight < 0) {
+      controlTopNewHeight += controlBottomNewHeight;
+      controlBottomNewHeight = 0;
+      bottomManipulated = true;
+    }
+
+    const getPaddingHeight = element => {
+      let style = window.getComputedStyle(element);
+      return parseInt(style.paddingTop) + parseInt(style.paddingBottom);
+    };
+
+    Splitter.controlTop.style.height = (controlTopNewHeight - getPaddingHeight(Splitter.controlTop)) + "px";
+    Splitter.controlBottom.style.height = (controlBottomNewHeight - getPaddingHeight(Splitter.controlBottom)) + "px";
+    Splitter.lastPosition = e.clientY;
+  },
+  
+  stop: function() {
+    document.onmousemove = null;
+    document.onmouseup = null;
+  }
 };


### PR DESCRIPTION
This is a pull request that @alanbuxey originally proposed in my fork of SAML-tracer. Thanks again, Alan!

The modification to SAML-tracer, contained in this pull request, allow the extension to be used in other browsers besides Firefox as well; namely Chrome and Opera. I think that's a great enhancement and intruduces a bunch of new possibilites!
(For example, just the other day I was talking to a customer who is constrained to use IE or Chrome; so this'd be an ideal solution for him to benefit from SAML-tracer as well!)

@jaimeperez, could you please submit SAML-tracer to the Chrome web store (https://chrome.google.com/webstore/category/extensions), too?
This would be the only "downside" that I can think of: The extension would have to be committed to two extension stores (Firefox + Chrome). Are you ok with that?