### PR TITLE
Bugfix/fix 302 redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+samltracer.zip

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2,6 +2,8 @@
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Specifying_background_scripts
 // The onOpenWindow event handler was slightly modified to be compatible with standard Firefox.
 
+var browser = browser || chrome
+
 browser.browserAction.onClicked.addListener((tab) => showTracerWindow());
 
 var tracerWindow = null;

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,7 +3,6 @@
 // The onOpenWindow event handler was slightly modified to be compatible with standard Firefox.
 
 var browser = browser || chrome
-
 browser.browserAction.onClicked.addListener((tab) => showTracerWindow());
 
 var tracerWindow = null;
@@ -16,14 +15,18 @@ function showTracerWindow() {
   }
 
   // If it wasn't yet opened or it was already closed -- create a new instance.
-  var url = browser.extension.getURL("/src/TraceWindow.html");
-  var creating = browser.windows.create({
+  let url = browser.extension.getURL("/src/TraceWindow.html");
+  let creating = browser.windows.create({
     url: url,
-    type: "panel",
+    type: "popup",
     height: 600,
     width: 800
-  });
-  creating.then(onCreated, onError);
+  }, onCreated);
+
+  if (creating) {
+    // Firefox uses a promise for window creation
+    creating.then(onCreated, onError); 
+  }
 }
 
 function onCreated(windowInfo) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,11 @@
     "description": "A debugger for viewing SAML messages",
     "manifest_version": 2,
     "version": "1.4",
-    "applications": {
-        "gecko": {
-          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
-        }
-    },
+//    "applications": {
+//        "gecko": {
+//          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
+//        }
+//    },
     "homepage_url": "https://github.com/UNINETT/SAML-tracer",
     "icons": {
         "48": "src/resources/images/saml-as-square.png"

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,22 @@
 {
-    "name": "SAML-tracer",
-    "description": "A debugger for viewing SAML messages",
-    "manifest_version": 2,
-    "version": "1.4",
-//    "applications": {
-//        "gecko": {
-//          "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"
-//        }
-//    },
-    "homepage_url": "https://github.com/UNINETT/SAML-tracer",
-    "icons": {
-        "48": "src/resources/images/saml-as-square.png"
-    },
-    "permissions": [
-        "webRequest",
-        "webRequestBlocking",
-        "<all_urls>"
-    ],
-    "background": {
-        "scripts": ["bootstrap.js"]
-    },
-    "browser_action": {
-        "default_icon": "src/resources/images/saml-as-square.png"
-    }
+  "name": "SAML-tracer",
+  "description": "A debugger for viewing SAML messages",
+  "author": "Olav Morken, Jaime Perez",
+  "manifest_version": 2,
+  "version": "1.4",
+  "homepage_url": "https://github.com/UNINETT/SAML-tracer",
+  "icons": {
+    "48": "src/resources/images/saml-as-square.png"
+  },
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
+  "background": {
+    "scripts": ["bootstrap.js"]
+  },
+  "browser_action": {
+    "default_icon": "src/resources/images/saml-as-square.png"
+  }
 }

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -216,7 +216,9 @@ SAMLTrace.Request.prototype = {
       parameters.forEach(parameter => {
         let splittedParameter = parameter.split('=');
         let name = splittedParameter[0];
-        let value = decodeURIComponent(splittedParameter[1] || '').replace(/\+/g, ' ');
+        // In theory the formData's values should remain urlencoded. But since the webRequest-API's 
+        // formData-object supplies these values decoded, we try to mime the same behaviour here.
+        let value = decodeURIComponent((splittedParameter[1] || '').replace(/\+/g, '%20'));
         formData[name] = [ value ];
       });
       return formData;

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -1,4 +1,6 @@
 // export SAMLTrace namespace to make ao. Request definitions available
+var browser = browser || chrome
+
 var EXPORTED_SYMBOLS = ["SAMLTrace"];
 
 if ("undefined" == typeof(SAMLTrace)) {

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -1,6 +1,4 @@
 // export SAMLTrace namespace to make ao. Request definitions available
-var browser = browser || chrome
-
 var EXPORTED_SYMBOLS = ["SAMLTrace"];
 
 if ("undefined" == typeof(SAMLTrace)) {
@@ -704,6 +702,7 @@ SAMLTrace.TraceWindow.prototype = {
 };
 
 SAMLTrace.TraceWindow.init = function() {
+  var browser = browser || chrome;
   let traceWindow = new SAMLTrace.TraceWindow();
   
   browser.webRequest.onBeforeRequest.addListener(

--- a/src/splitter.js
+++ b/src/splitter.js
@@ -1,42 +1,52 @@
 Splitter = {
-    setup: function(controlTop, controlBottom, dragger) {
-        Splitter.controlTop = controlTop;
-        Splitter.controlBottom = controlBottom;
-        dragger.onmousedown = Splitter.mousedown;
-    },
-    mousedown: function(e) {
-        Splitter.lastPosition = e.clientY;
-        document.onmousemove = Splitter.move;
-        document.onmouseup = Splitter.stop;
-    },
-    move: function(e) {
-        let vMovement = e.clientY - Splitter.lastPosition;
-        let controlTopNewHeight = Splitter.controlTop.clientHeight + vMovement;
-        let controlBottomNewHeight = Splitter.controlBottom.clientHeight - vMovement;
+  setup: function(controlTop, controlBottom, dragger) {
+    const justifyHeights = (controlTop, controlBottom) => {
+      let maxHeight = controlTop.clientHeight + controlBottom.clientHeight;
+      controlTop.style.height = maxHeight / 2 + "px";
+      controlBottom.style.height = maxHeight / 2 + "px";
+    };
 
-        let position = e.clientY;
-        if (controlTopNewHeight < 0) {
-            controlBottomNewHeight += controlTopNewHeight;
-            controlTopNewHeight = 0;
-            topManipulated = true;
-        }
-        if (controlBottomNewHeight < 0) {
-            controlTopNewHeight += controlBottomNewHeight;
-            controlBottomNewHeight = 0;
-            bottomManipulated = true;
-        }
+    justifyHeights(controlTop, controlBottom);
+    Splitter.controlTop = controlTop;
+    Splitter.controlBottom = controlBottom;
+    dragger.onmousedown = Splitter.mousedown;
+  },
 
-        const getPaddingHeight = element => {
-            let style = window.getComputedStyle(element);
-            return parseInt(style.paddingTop) + parseInt(style.paddingBottom);
-        };
+  mousedown: function(e) {
+    Splitter.lastPosition = e.clientY;
+    document.onmousemove = Splitter.move;
+    document.onmouseup = Splitter.stop;
+  },
 
-        Splitter.controlTop.style.height = (controlTopNewHeight - getPaddingHeight(Splitter.controlTop)) + "px";
-        Splitter.controlBottom.style.height = (controlBottomNewHeight - getPaddingHeight(Splitter.controlBottom)) + "px";
-        Splitter.lastPosition = e.clientY;
-    },
-    stop: function() {
-        document.onmousemove = null;
-        document.onmouseup = null;
+  move: function(e) {
+    let vMovement = e.clientY - Splitter.lastPosition;
+    let controlTopNewHeight = Splitter.controlTop.clientHeight + vMovement;
+    let controlBottomNewHeight = Splitter.controlBottom.clientHeight - vMovement;
+
+    let position = e.clientY;
+    if (controlTopNewHeight < 0) {
+      controlBottomNewHeight += controlTopNewHeight;
+      controlTopNewHeight = 0;
+      topManipulated = true;
     }
+    if (controlBottomNewHeight < 0) {
+      controlTopNewHeight += controlBottomNewHeight;
+      controlBottomNewHeight = 0;
+      bottomManipulated = true;
+    }
+
+    const getPaddingHeight = element => {
+      let style = window.getComputedStyle(element);
+      return parseInt(style.paddingTop) + parseInt(style.paddingBottom);
+    };
+
+    Splitter.controlTop.style.height = (controlTopNewHeight - getPaddingHeight(Splitter.controlTop)) + "px";
+    Splitter.controlBottom.style.height = (controlBottomNewHeight - getPaddingHeight(Splitter.controlBottom)) + "px";
+    Splitter.lastPosition = e.clientY;
+  },
+  
+  stop: function() {
+    document.onmousemove = null;
+    document.onmouseup = null;
+  }
 };


### PR DESCRIPTION
This PR fixes a problem with redirected 302 requests, which I noticed while working on the PR for the Chrome Compatibility (#45):

For redirected requests, it is known that to be necessary to manually adjust the redirected request (see [here](https://github.com/UNINETT/SAML-tracer/pull/23#issuecomment-345540591)). However, during this manually adjustment it's additionally necessary to include the HTTP method in the `UniqueRequestId`. This is necessary in order to determine the redirected request from the traced requests (collected in `httpRequests`). If the HTTP method is not taken into account in the UniqueRequestId, the first request (and not the subsequent second one) will always be found and thus displayed twice in the UI.

Please note: To avoid potential merge conflicts I branched directly from #45. So this PR may seem bigger than it is. So it'd be advisable to first merge #45 and take a look at the then probably smaller diff again ;-)