### PR TITLE
The clear-button now removes tabs

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -699,6 +699,8 @@ SAMLTrace.TraceWindow.prototype = {
   },
 
   'showRequest' : function(requestItem) {
+    var requestInfoTabbox = document.getElementById('request-info-tabbox');
+    requestInfoTabbox.innerText = "";
     var requestInfoContent = document.getElementById('request-info-content');
     if (requestItem === null) {
       requestInfoContent.innerText = "";
@@ -706,8 +708,6 @@ SAMLTrace.TraceWindow.prototype = {
     }
     this.requestItem = requestItem;
 
-    var requestInfoTabbox = document.getElementById('request-info-tabbox');
-    requestInfoTabbox.innerText = "";
     for (var i = 0; i < requestItem.availableTabs.length; i++) {
       var name = requestItem.availableTabs[i];
       this.addRequestTab(name, requestInfoTabbox, requestInfoContent);


### PR DESCRIPTION
This is a small issue but something that really bugs me for quite a while:

If you traced some requests and then hit the clear-button, the requests were removed. However, a click on one of the tabs (http, parameters, SAML) would reveal the last request:

![c38f1e9d-d5a0-4194-baf1-cc443d4c14a4](https://user-images.githubusercontent.com/17160647/46370683-84c1a280-c686-11e8-9a4e-346d1afe55e1.gif)

After the fix, the tabs will also be removed, which means that this problem can no longer occur:

![91dcd78b-5ba3-4ade-a5ed-4a58193f277d](https://user-images.githubusercontent.com/17160647/46370860-0c0f1600-c687-11e8-9ca3-9c27d63c7700.gif)
