### PR TITLE
Show resource if filter not active

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -668,6 +668,10 @@ SAMLTrace.TraceWindow.prototype = {
         var isVisible = tracer.isRequestVisible(response);
         if (!isVisible) {
           requestDiv.classList.add("isRessource");
+          
+          if (!tracer.filterResources) {
+            requestDiv.classList.add("displayAnyway");
+          }
         }
         
         entry.isVisible = isVisible;


### PR DESCRIPTION
There's a bug which leads to trace records of resources being filtered even if the _Filter resources_ button is deactivated.

This happens because the CSS class `displayAnyway` isn't appended to a resource-request in the `attachResponseToRequest` function. Only a click on  _Filter resources_ adds the class to the resource-requests.

The correct behavior would be to add the class directly within `attachResponseToRequest` function if the current state of `filterResources` is false.

---

*Current behavior in SAML-tracer v1.5.1*
Notice the filtered requests even though the filter button is not active:

![73125401-20c6-4132-a07c-191cb45037b7](https://user-images.githubusercontent.com/17160647/46554560-03198100-c8e1-11e8-8f30-ca7a452c6545.gif)


*This pull request corrects the behavior as shown beneath*

![714ef735-5785-4290-bf15-4b8e66eea19f](https://user-images.githubusercontent.com/17160647/46554803-b2eeee80-c8e1-11e8-91b1-fa238956d11a.gif)

