### PR TITLE
Cookie- and Set-Cookie-headers are missing in Chrome

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -843,7 +843,19 @@ SAMLTrace.TraceWindow.prototype = {
 SAMLTrace.TraceWindow.init = function() {
   var browser = browser || chrome;
   let traceWindow = new SAMLTrace.TraceWindow();
-  
+
+  let isFirefox = () => {
+    return typeof InstallTrigger !== 'undefined';
+  }
+
+  let getOnBeforeSendHeadersExtraInfoSpec = () => {
+    return isFirefox() ? ["blocking", "requestHeaders"] : ["blocking", "requestHeaders", "extraHeaders"];
+  };
+
+  let getOnHeadersReceivedExtraInfoSpec = () => {
+    return isFirefox() ? ["blocking", "responseHeaders"] : ["blocking", "responseHeaders", "extraHeaders"];
+  };
+
   browser.webRequest.onBeforeRequest.addListener(
     traceWindow.saveNewRequest,
     {urls: ["<all_urls>"]},
@@ -853,13 +865,13 @@ SAMLTrace.TraceWindow.init = function() {
   browser.webRequest.onBeforeSendHeaders.addListener(
     traceWindow.attachHeadersToRequest,
     {urls: ["<all_urls>"]},
-    ["blocking", "requestHeaders"]
+    getOnBeforeSendHeadersExtraInfoSpec()
   );
 
   browser.webRequest.onHeadersReceived.addListener(
     traceWindow.attachResponseToRequest,
     {urls: ["<all_urls>"]},
-    ["blocking", "responseHeaders"]
+    getOnHeadersReceivedExtraInfoSpec()
   );
 };
 


### PR DESCRIPTION
While debugging a  web application the other day I noticed that SAML-tracer doesn't record the `Cookie`- or `Set-Cookie`-header in Chrome.
This was a really lucky discovery since I usually don't use Chrome. 

It's a quite sever bug as users of SAML-tracer in Chrome will mistakenly think that their applications don't issue cookies albeit in fact they do!

Why does this bug occur?
This is due to a change in Chrome 72: Starting from this version the `Cookie`-, `Set-Cookie`- and some other headers are only accessible by specifying `extraHeaders` in `opt_extraInfoSpec`. 
See: https://developer.chrome.com/extensions/webRequest

Hence I added this option, although there's one downside:

> Note: Specifying 'extraHeaders' in opt_extraInfoSpec may have a negative impact on performance, hence it should only be used when really necessary. 

But I think there's no way to get around this. SAML-tracer has to inspect each request since there's always a chance for cookies being involved.