### PR TITLE
Deactivate autoscroll on scrolling up doesn't work in Chrome

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -146,7 +146,7 @@ ui = {
     let autoScrollButton = document.getElementById("button-autoscroll");
 
     requestList.addEventListener("scroll", e => {
-      let wasScrolledUp = requestList.scrollTop < requestList.scrollTopMax;
+      let wasScrolledUp = requestList.scrollTop < requestList.scrollHeight - requestList.clientHeight;
       let activateAutoscroll = !wasScrolledUp;
 
       ui.setButtonState(autoScrollButton, activateAutoscroll);


### PR DESCRIPTION
While working on the Chrome Cookie fix I noticed that the deactivate autoscroll function doesn't work in Chrome. Usually autoscroll gets automatically deactived when you scroll upwards. This doesn't work in Chrome and is due to `Element.scrollTopMax` being non-standard; even in Firefox...

> This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.

See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTopMax