### PR TITLE
fix request counting

### DIFF
--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -646,7 +646,7 @@ SAMLTrace.TraceWindow.prototype = {
   'updateStatusBar' : function() {
     var hiddenElementsString = "";
     if (this.filterResources) {
-      hiddenElementsString = ` (${this.httpRequests.filter(req => !req.isVisible).length} hidden)`;
+      hiddenElementsString = ` (${this.httpRequests.filter(req => typeof req.isVisible !== "undefined" && !req.isVisible).length} hidden)`;
     }
     var status = `${this.httpRequests.length} requests received ${hiddenElementsString}`;
     var statusItem = document.getElementById('statuspanel');

--- a/src/SAMLTrace.js
+++ b/src/SAMLTrace.js
@@ -676,6 +676,11 @@ SAMLTrace.TraceWindow.prototype = {
   },
 
   'saveNewRequest' : function(request) { // onBeforeRequest
+    if (request.requestId.startsWith("fakeRequest-")) {
+      // Skip tracing fake requests that are issued by firefox for e.g. thumbnails of websites from about:blank
+      return;
+    }
+
     let tracer = SAMLTrace.TraceWindow.instance();
     if (tracer.pauseTracing) {
       // Skip tracing new requests


### PR DESCRIPTION
This pull request fixes two bugs which caused an incorrect hidden request count:
1. Requests without responses haven't been counted correctly.
2. "fakeRequests" led to incomprehensible counts.

**Regarding 1**:
This can be very easily be reproduced by accessing any arbitrary non-existent ressource. E.g. http://www.non-existent-website.com/
SAML-tracer collects the GET and displays the request. Since there'll never be a response for this request, this entry will not get the `isVisible` property assigned. Entries without that property are shown in the upper pane. Everything fine so far.
But unfortunately SAML-tracer counts this request as a hidden one due to the property being `undefined`:

![image](https://user-images.githubusercontent.com/17160647/67151822-9db9e780-f2cb-11e9-9998-58f41af26717.png)


**Regarding 2**:
The webRequest-API implementation of Firefox issues [fakeRequests](https://dxr.mozilla.org/mozilla-central/source/toolkit/components/extensions/webrequest/WebRequest.jsm?q=WebRequest.jsm&redirect_type=direct#282) in some situations which should be ignored by SAML-tracer.
This can be reproduced by first opening a new tab (`about:blank`). Firefox may list some items with thumbnails on that new tab. E.g. some recently visited websites, recommended news and so on. 
Now click on http://www.non-existent-website.com/.
The result: SAML-tracer traces the request to the non-existent website and some invisible fake requests...

![image](https://user-images.githubusercontent.com/17160647/67151824-a4e0f580-f2cb-11e9-871a-be7ec701db9a.png)
